### PR TITLE
Fix typo

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -66,7 +66,7 @@ abstract class Action
 
         if (!empty($extraneous)) {
             return $self
-                ->fail("Extraneous keys: " . implode(', ', $missing));
+                ->fail("Extraneous keys: " . implode(', ', $extraneous));
         }
 
         return $self->handle($input);


### PR DESCRIPTION
Fix a typo in the `execute` method that was preventing the correct display of extraneous keys.
