### PR TITLE
Ensure that published stubs can be used for making new actions

### DIFF
--- a/src/Laravel/MakeAction.php
+++ b/src/Laravel/MakeAction.php
@@ -71,7 +71,7 @@ class MakeAction extends Command
     protected function getStub()
     {
         if (file_exists(base_path('stubs/action.stub'))) {
-            return file_get_contents(base_path('stubs/action.stub'));
+            $this->stub = file_get_contents(base_path('stubs/action.stub'));
         }
 
         $this->stub = file_get_contents(__DIR__ . '/stubs/action.stub');


### PR DESCRIPTION
This PR fixes a bug that was preventing the `MakeAction` command from reading locally published
class stubs. 
