### PR TITLE
Add run method as non-static trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `stagerightlabs/actions` will be documented in this file
 
+## 0.00.41 - 2022-01-08
+
+### Added
+
+- I was hoping to be able to use the same `execute()` method to trigger actions both statically and from within an object context.  However, this turns out not to be practical.  Instead `execute()` will be used for static triggering, and a new `run()` method will be used to trigger instantiated action classes.
+
 ## 0.00.40 - 2022-01-07
 
 ### Changed

--- a/src/Action.php
+++ b/src/Action.php
@@ -85,7 +85,7 @@ abstract class Action
      * Handle the action.
      *
      * @param Action|array $input
-     * @return self
+     * @return static
      */
     abstract public function handle($input = []);
 
@@ -93,9 +93,9 @@ abstract class Action
      * Flag this action as having completed.
      *
      * @param string $message
-     * @return self
+     * @return static
      */
-    protected function complete($message = '')
+    protected function complete($message = ''): static
     {
         $this->hasCompleted = true;
         $this->message = $message;
@@ -107,9 +107,9 @@ abstract class Action
      * Flag this action as having failed.
      *
      * @param string $message
-     * @return self
+     * @return static
      */
-    protected function fail($message = '')
+    protected function fail($message = ''): static
     {
         $this->hasCompleted = false;
         $this->message = $message;
@@ -122,7 +122,7 @@ abstract class Action
      *
      * @return bool
      */
-    public function completed()
+    public function completed(): bool
     {
         return $this->hasCompleted == true;
     }
@@ -132,7 +132,7 @@ abstract class Action
      *
      * @return bool
      */
-    public function failed()
+    public function failed(): bool
     {
         return $this->hasCompleted == false;
     }
@@ -142,7 +142,7 @@ abstract class Action
      *
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -154,7 +154,7 @@ abstract class Action
      * @param array|string $keys
      * @return array
      */
-    protected function missingInputKeys($array)
+    protected function missingInputKeys($array): array
     {
         $missing = [];
 
@@ -174,7 +174,7 @@ abstract class Action
      * @param array|string $keys
      * @return array
      */
-    protected function extraneousInputKeys($array)
+    protected function extraneousInputKeys($array): array
     {
         $extraneous = [];
         $expected = array_merge($this->required(), $this->optional());
@@ -193,7 +193,7 @@ abstract class Action
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (!empty($this->message)) {
             return $this->message;

--- a/src/Action.php
+++ b/src/Action.php
@@ -51,7 +51,7 @@ abstract class Action
      * @param array $input
      * @return static
      */
-    public static function execute($input = []): static
+    public static function execute($input = [])
     {
         return (new static())->run($input);
     }
@@ -62,7 +62,7 @@ abstract class Action
      * @param array $input
      * @return static
      */
-    public function run($input = []): static
+    public function run($input = [])
     {
         $missing = $this->missingInputKeys($input);
 
@@ -95,7 +95,7 @@ abstract class Action
      * @param string $message
      * @return static
      */
-    protected function complete($message = ''): static
+    protected function complete($message = '')
     {
         $this->hasCompleted = true;
         $this->message = $message;
@@ -109,7 +109,7 @@ abstract class Action
      * @param string $message
      * @return static
      */
-    protected function fail($message = ''): static
+    protected function fail($message = '')
     {
         $this->hasCompleted = false;
         $this->message = $message;
@@ -142,7 +142,7 @@ abstract class Action
      *
      * @return string
      */
-    public function getMessage(): string
+    public function getMessage()
     {
         return $this->message;
     }
@@ -154,7 +154,7 @@ abstract class Action
      * @param array|string $keys
      * @return array
      */
-    protected function missingInputKeys($array): array
+    protected function missingInputKeys($array)
     {
         $missing = [];
 
@@ -174,7 +174,7 @@ abstract class Action
      * @param array|string $keys
      * @return array
      */
-    protected function extraneousInputKeys($array): array
+    protected function extraneousInputKeys($array)
     {
         $extraneous = [];
         $expected = array_merge($this->required(), $this->optional());
@@ -193,7 +193,7 @@ abstract class Action
      *
      * @return string
      */
-    public function __toString(): string
+    public function __toString()
     {
         if (!empty($this->message)) {
             return $this->message;

--- a/src/Action.php
+++ b/src/Action.php
@@ -46,31 +46,39 @@ abstract class Action
     }
 
     /**
-     * Trigger the execution of this action.
+     * Trigger the execution of this action from a static context.
      *
      * @param array $input
-     * @return self
+     * @return static
      */
-    public static function execute($input = [])
+    public static function execute($input = []): static
     {
-        $isStatic = !(isset($this) && $this instanceof self);
-        $self = $isStatic ? new static() : $this;
+        return (new static())->run($input);
+    }
 
-        $missing = $self->missingInputKeys($input);
+    /**
+     * Trigger the execution of this action from an object context.
+     *
+     * @param array $input
+     * @return static
+     */
+    public function run($input = []): static
+    {
+        $missing = $this->missingInputKeys($input);
 
         if (!empty($missing)) {
-            return $self
+            return $this
                 ->fail("Missing expected keys: " . implode(', ', $missing));
         }
 
-        $extraneous = $self->extraneousInputKeys($input);
+        $extraneous = $this->extraneousInputKeys($input);
 
         if (!empty($extraneous)) {
-            return $self
+            return $this
                 ->fail("Extraneous keys: " . implode(', ', $extraneous));
         }
 
-        return $self->handle($input);
+        return $this->handle($input);
     }
 
     /**

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -22,7 +22,7 @@ class ActionTest extends TestCase
     /** @test */
     public function actions_can_be_called_in_an_object_context()
     {
-        $action = (new CompletingExampleAction())->execute();
+        $action = (new CompletingExampleAction())->run();
 
         $this->assertInstanceOf(Action::class, $action);
         $this->assertInstanceOf(CompletingExampleAction::class, $action);
@@ -82,7 +82,7 @@ class ActionTest extends TestCase
     /** @test */
     public function actions_will_fail_when_required_input_keys_are_missing_in_an_object_context()
     {
-        $action = (new RequiredInputExampleAction())->execute();
+        $action = (new RequiredInputExampleAction())->run();
 
         $this->assertFalse($action->completed());
     }


### PR DESCRIPTION
This PR adds a new `run()` method to trigger actions from within an object
context.
